### PR TITLE
Remove `gen-tex-files` run from the default build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 		"gen-tex-files": "node genTexFiles.js",
 		"encode-tex-files": "node encodeTexFiles.js",
 		"install-fonts": "gulp download-fonts && gulp install-fonts && node encodeFonts.js",
-		"devbuild": "npm run gen-tex-files && npm run encode-tex-files && webpack --mode development",
-		"build": "npm run gen-tex-files && npm run encode-tex-files && webpack",
+		"devbuild": "npm run encode-tex-files && webpack --mode development",
+		"build": "npm run encode-tex-files && webpack",
 		"postbuild": "node cleanup.js && npm run install-fonts"
 	},
 	"author": "Jim Fowler",


### PR DESCRIPTION
As the repository now bundles both the tex files and the corresponding
core dump and compiled WASM it no longer makes sense to run
`gen-tex-files` as a default step when building TikZJax. Regenerating
these files should only be done by somebody who knows what they are
doing, as messing up this step could easily break TikZJax at runtime.